### PR TITLE
Hotfix

### DIFF
--- a/src/App.xaml
+++ b/src/App.xaml
@@ -9,6 +9,8 @@
                 <ResourceDictionary Source="Resources\ExtendedTextBox.xaml"/>
                 <ResourceDictionary Source="Resources\CloseButton.xaml"/>
                 <ResourceDictionary Source="Resources\CorneredButton.xaml"/>
+                <ResourceDictionary Source="Resources\CustomProgressBar.xaml"/>
+                <ResourceDictionary Source="Resources\CustomScrollBar.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/src/MainWindow.xaml
+++ b/src/MainWindow.xaml
@@ -28,7 +28,7 @@
                 <sys:String>Progress</sys:String>
             </CollectionViewSource.LiveSortingProperties>
         </CollectionViewSource>
-        
+
         <Style TargetType="{x:Type Label}">
             <Setter Property="FontSize" Value="25"/>
         </Style>
@@ -54,7 +54,7 @@
 
         <ListBox ItemsSource="{Binding Source={StaticResource TaskSource}}"
                  Background="#EDEDED" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                 Grid.Row="1" ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 Grid.Row="1" ScrollViewer.VerticalScrollBarVisibility="Auto"                 
                  HorizontalContentAlignment="Stretch">
             <ListBox.ItemTemplate>
                 <DataTemplate DataType="{x:Type vms:TaskViewModel}">
@@ -78,13 +78,25 @@
                                     Command="{Binding DataContext.RemoveTaskCommand, 
                                               RelativeSource={RelativeSource AncestorType={x:Type ListBox}}}"/>
                             
-                            <TextBlock Text="{Binding Progress, Mode=OneWay, StringFormat={}{0} %}" DockPanel.Dock="Right" Margin="20,0"/>
+                            <TextBlock Text="{Binding Progress, Mode=OneWay, StringFormat={}{0} %}"
+                                       DockPanel.Dock="Right" Margin="20,0"/>
                         </DockPanel>
 
-                        <ProgressBar Margin="3" Value="{Binding Progress, Mode=OneWay}" Height="5" Minimum="0" Maximum="100"/>
+                        <ProgressBar Margin="3" Value="{Binding Progress, Mode=OneWay}"
+                                     Height="5" Minimum="0" Maximum="100"
+                                     Style="{StaticResource ProgressBarStyle}"
+                                     Background="#EAEAEA" Foreground="#66C529"/>
                     </DockPanel>
                 </DataTemplate>
             </ListBox.ItemTemplate>
+            <ListBox.Resources>
+                <Style TargetType="{x:Type ScrollBar}" 
+                       BasedOn="{StaticResource ScrollBarStyle}">
+                    <Setter Property="Foreground" Value="#25A8E0"/>
+                    <Setter Property="Background" Value="#BABABA"/>
+                    <Setter Property="Width" Value="15"/>
+                </Style>
+            </ListBox.Resources>
         </ListBox>
 
         <DockPanel Margin="10" Grid.Column="1" Grid.Row="1" LastChildFill="False">

--- a/src/Resources/CloseButton.xaml
+++ b/src/Resources/CloseButton.xaml
@@ -1,19 +1,29 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+    <Path x:Key="CloseCircleGlyph" Fill="White"
+          Data="M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41
+                16.41,20 12,20M12,2C6.47,2 2,6.47 2,12C2,17.53 6.47,22 12,22C17.53,22 22,17.53 
+                22,12C22,6.47 17.53,2 12,2M14.59,8L12,10.59L9.41,8L8,9.41L10.59,12L8,14.59L9.41,16L12,13.41L14.59,16L16,14.59L13.41,12L16,9.41L14.59,8Z"/>
+
     <Style TargetType="{x:Type Button}" x:Key="CloseButton">
         <Setter Property="Width" Value="28"/>
         <Setter Property="Height" Value="28"/>
         <Setter Property="Foreground" Value="#D0D0D0"/>
         <Setter Property="FontSize" Value="23"/>
-        <Setter Property="FontFamily" Value="Segoe MDL2 Assets"/>
-        <Setter Property="Content" Value="&#xEA39;"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
                     <Grid>
-                        <Ellipse Stroke="Transparent" StrokeThickness="0"/>
-                        <ContentPresenter VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                        <Ellipse StrokeThickness="0"
+                                 Fill="#D0D0D0">
+                            <Ellipse.OpacityMask>
+                                <VisualBrush Stretch="Fill"
+                                             Visual="{StaticResource CloseCircleGlyph}"/>
+                            </Ellipse.OpacityMask>
+                        </Ellipse>
+                        <ContentPresenter VerticalAlignment="Center" 
+                                          HorizontalAlignment="Center"/>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/Resources/CustomProgressBar.xaml
+++ b/src/Resources/CustomProgressBar.xaml
@@ -1,0 +1,23 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Style TargetType="{x:Type ProgressBar}" x:Key="ProgressBarStyle">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ProgressBar}">
+                    <Grid Height="{TemplateBinding Height}">
+                        <Border x:Name="PART_Track" 
+                                BorderThickness="0" Margin="0" Padding="0"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding Background}"/>
+                        <Border x:Name="PART_Indicator" 
+                                HorizontalAlignment="Left"
+                                BorderThickness="0" Margin="0" Padding="0"
+                                Background="{TemplateBinding Foreground}"
+                                BorderBrush="{TemplateBinding Foreground}"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/Resources/CustomScrollBar.xaml
+++ b/src/Resources/CustomScrollBar.xaml
@@ -1,0 +1,44 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Style TargetType="{x:Type ScrollBar}" x:Key="ScrollBarStyle">
+        <Setter Property="OverridesDefaultStyle" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ScrollBar}">
+                    <Grid Width="{TemplateBinding Width}" Height="{TemplateBinding Height}">
+                        <Border x:Name="Border"
+                                Margin="0" Padding="0"
+                                BorderThickness="0"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="Transparent"/>
+                        <Track x:Name="PART_Track" IsDirectionReversed="True" >
+                            <Track.Thumb>
+                                <Thumb Background="{TemplateBinding Foreground}"
+                                       Margin="0"  Padding="0"
+                                       BorderBrush="{TemplateBinding Foreground}"
+                                       BorderThickness="0" IsTabStop="False"
+                                       Focusable="False" SnapsToDevicePixels="True"
+                                       OverridesDefaultStyle="True">
+                                    <Thumb.Style>
+                                        <Style TargetType="{x:Type Thumb}">
+                                            <Setter Property="Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate TargetType="{x:Type Thumb}">
+                                                        <Border Background="{TemplateBinding Background}"
+                                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                                BorderThickness="{TemplateBinding BorderThickness}"/>
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
+                                        </Style>
+                                    </Thumb.Style>
+                                </Thumb>
+                            </Track.Thumb>
+                        </Track>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/TaskListAppTest.csproj
+++ b/src/TaskListAppTest.csproj
@@ -81,11 +81,19 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Page Include="Resources\CustomScrollBar.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Resources\CloseButton.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Resources\CorneredButton.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Resources\CustomProgressBar.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/ViewModels/MainViewModel.cs
+++ b/src/ViewModels/MainViewModel.cs
@@ -85,7 +85,7 @@ namespace TaskListAppTest.ViewModels
 
         private void TimeToCheck(object sender, ElapsedEventArgs e)
         {
-            if(workerTimer.Enabled && TaskList.All(t => t.IsCompleted))
+            if(workerTimer.Enabled && (!TaskList.Any() || TaskList.All(t => t.IsCompleted)))
             {
                 workerTimer.Stop();
             }

--- a/src/ViewModels/TaskViewModel.cs
+++ b/src/ViewModels/TaskViewModel.cs
@@ -67,6 +67,7 @@ namespace TaskListAppTest.ViewModels
 
 
         private readonly TaskModel model;
+        private readonly Timer refreshTimer;
         private int progress;
 
         /// <summary>
@@ -89,11 +90,20 @@ namespace TaskListAppTest.ViewModels
 
             model = new TaskModel(name, time);
 
-            timer.Elapsed += TimeToUpdate;
+            refreshTimer = timer;
+            refreshTimer.Elapsed += TimeToUpdate;
         }
 
 
-        private void TimeToUpdate(object sender, ElapsedEventArgs e) => Progress = (int)(GetPercentageProgress() * 100);
+        private void TimeToUpdate(object sender, ElapsedEventArgs e) 
+        {
+            Progress = (int)(GetPercentageProgress() * 100);
+            
+            if(IsCompleted)
+            {
+                refreshTimer.Elapsed -= TimeToUpdate;
+            }
+        }
 
         private double GetPercentageProgress()
         {


### PR DESCRIPTION
BugFixing:
+ if user delete all completed Tasks before timer elapsed, timer never stops
+ if Task is completed, there is no reason to handle timer elapsing
+ if Task is completed and deleted from collection, timer has implicit link to that Task from handler until app was closed

Styles:
+ Removed CloseButton Content
+ Added CloseButton Ellipse Opacity Mask by Path
+ Added custom style for ScrollBar
+ Added custom style for ProgressBar (it's not necessary on Windows 10)